### PR TITLE
Add CHAOS reward to current FeeManager

### DIFF
--- a/contracts/FeeManager.sol
+++ b/contracts/FeeManager.sol
@@ -33,6 +33,10 @@ contract FeeManager is IFeeManager, Ownable {
         uint256 chaosAmount
     );
 
+    event RewardsConvertedToUsdc(
+        uint256 usdcAmount
+    );
+
     modifier onlyVault() {
         require(address(vault) == msg.sender, "Only vault can call");
         _;
@@ -105,6 +109,8 @@ contract FeeManager is IFeeManager, Ownable {
         accumulatedRewardsPerShare =
             accumulatedRewardsPerShare +
             FullMath.mulDiv(rewards, REWARDS_PRECISION, vault.totalSupply());
+
+        emit RewardsConvertedToUsdc(rewards);
     }
 
     function claimFees(address claimer) public {

--- a/contracts/FeeManager.sol
+++ b/contracts/FeeManager.sol
@@ -15,7 +15,7 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 contract FeeManager is IFeeManager, Ownable {
     using SafeERC20 for IERC20;
 
-    uint256 internal _rate;
+    uint256 public rate;
     IERC20 public immutable chaos;
     IERC20 public immutable vault;
     IERC20 public immutable usdc;
@@ -73,8 +73,8 @@ contract FeeManager is IFeeManager, Ownable {
         IERC20(chaos).transfer(owner(), balance);
     }
 
-    function setRate(uint256 rate) external onlyOwner {
-        _rate = rate;
+    function setRate(uint256 newRate) external onlyOwner {
+        rate = newRate;
     }
 
     function setRewardDebt(address _user, uint256 _amount) external onlyVault {
@@ -124,8 +124,8 @@ contract FeeManager is IFeeManager, Ownable {
         rewardDebt[claimer] = totalReward;
 
         uint256 rewardsToHarvestInChaos = (rewardsToHarvest *
-            _rate *
-            10**(_CHAOS_DECIMALS-_USDC_DECIMALS)) / 100;
+            rate *
+            10**(_CHAOS_DECIMALS - _USDC_DECIMALS)) / 100;
 
         usdc.safeTransfer(claimer, rewardsToHarvest);
 

--- a/contracts/FeeManager.sol
+++ b/contracts/FeeManager.sol
@@ -15,13 +15,23 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 contract FeeManager is IFeeManager, Ownable {
     using SafeERC20 for IERC20;
 
+    uint256 internal _rate;
+    IERC20 public immutable chaos;
     IERC20 public immutable vault;
     IERC20 public immutable usdc;
     ISwapRouter02 public immutable router;
     uint256 public accumulatedRewardsPerShare;
     mapping(address => uint256) public rewardDebt;
     uint256 public constant REWARDS_PRECISION = 1e24;
+    uint8 private constant _USDC_DECIMALS = 6;
+    uint8 private constant _CHAOS_DECIMALS = 18;
     uint24 public immutable feeTier;
+
+    event RewardsClaimed(
+        address indexed user,
+        uint256 usdcAmount,
+        uint256 chaosAmount
+    );
 
     modifier onlyVault() {
         require(address(vault) == msg.sender, "Only vault can call");
@@ -31,6 +41,7 @@ contract FeeManager is IFeeManager, Ownable {
     constructor(
         address vault_,
         address usdc_,
+        address chaos_,
         address uniSwapRouter_,
         uint24 feeTier_
     ) {
@@ -43,6 +54,7 @@ contract FeeManager is IFeeManager, Ownable {
         feeTier = feeTier_;
         vault = IERC20(vault_);
         usdc = IERC20(usdc_);
+        chaos = IERC20(chaos_);
         router = ISwapRouter02(uniSwapRouter_);
 
         transferOwnership(msg.sender);
@@ -52,8 +64,17 @@ contract FeeManager is IFeeManager, Ownable {
     function withdrawEmergency() external onlyOwner {
         uint256 balance = usdc.balanceOf(address(this));
         require(balance > 0, "FeeManager: No USDC to withdraw");
-
         usdc.safeTransfer(owner(), balance);
+    }
+
+    function withdrawalChaos() external onlyOwner {
+        uint256 balance = chaos.balanceOf(address(this));
+        require(balance > 0, "FeeManager: No balance to withdrawal");
+        IERC20(chaos).transfer(owner(), balance);
+    }
+
+    function setRate(uint256 rate) external onlyOwner {
+        _rate = rate;
     }
 
     function setRewardDebt(address _user, uint256 _amount) external onlyVault {
@@ -100,10 +121,19 @@ contract FeeManager is IFeeManager, Ownable {
             return;
         }
 
-        // TODO: Add event
         rewardDebt[claimer] = totalReward;
 
+        uint256 rewardsToHarvestInChaos = (rewardsToHarvest *
+            _rate *
+            10**(_CHAOS_DECIMALS-_USDC_DECIMALS)) / 100;
+
         usdc.safeTransfer(claimer, rewardsToHarvest);
+
+        if (rewardsToHarvestInChaos > 0) {
+            chaos.safeTransfer(claimer, rewardsToHarvestInChaos);
+        }
+
+        emit RewardsClaimed(claimer, rewardsToHarvest, rewardsToHarvestInChaos);
     }
 
     function _swapToUSDC(address token, uint256 feesToken)

--- a/contracts/__mocks__/MockERC20.sol
+++ b/contracts/__mocks__/MockERC20.sol
@@ -1,13 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.13;
 
-import {
-    ERC20Upgradeable
-} from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
-contract MockERC20 is ERC20Upgradeable {
-    constructor() {
-        __ERC20_init("", "TOKEN");
-        _mint(msg.sender, 100000e18);
+contract MockERC20 is ERC20 {
+    constructor() ERC20("CHAOS", "CHAOS") {
+        _mint(msg.sender, 1000000 * 10**18);
     }
 }

--- a/contracts/interfaces/IFeeManager.sol
+++ b/contracts/interfaces/IFeeManager.sol
@@ -22,6 +22,12 @@ interface IFeeManager {
     // Function to emergency withdraw all the USDC of the contract (Only Owner)
     function withdrawEmergency() external;
 
+    // Function to withdraw all CHAOS of the contract (Only Owner)
+    function withdrawalChaos() external;
+
+    // Set conversion rate between USDC and CHAOS (Only Owner)
+    function setRate(uint256 rate) external;
+
     // Setter for a user's rewardDebt (can only be called by the vault)
     function setRewardDebt(address _user, uint256 _amount) external;
 

--- a/deploy/FeeManager.deploy.ts
+++ b/deploy/FeeManager.deploy.ts
@@ -5,6 +5,7 @@ import { getAddresses, Addresses } from "../src/addresses";
 import { sleep } from "../src/utils";
 
 const vaultAddress = "0x3Fd7957D9F98D46c755685B67dFD8505468A7Cb6"; // TODO: Automatize deploy vault
+const chaosToken = "0x0000000000000000000000000000000000000000";
 
 const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   if (
@@ -29,7 +30,13 @@ const func: DeployFunction = async (hre: HardhatRuntimeEnvironment) => {
   const { deployer } = await getNamedAccounts();
   await deploy("FeeManager", {
     from: deployer,
-    args: [vaultAddress, addresses.USDC, addresses.SwapRouter02, 10000],
+    args: [
+      vaultAddress,
+      addresses.USDC,
+      chaosToken,
+      addresses.SwapRouter02,
+      10000,
+    ],
     log: hre.network.name != "hardhat" ? true : false,
   });
 };

--- a/scripts/verify/verifyFeeManager.ts
+++ b/scripts/verify/verifyFeeManager.ts
@@ -6,7 +6,7 @@ const vaultAddress = "0x3Fd7957D9F98D46c755685B67dFD8505468A7Cb6"; // TODO: Auto
 async function main() {
   const addresses: Addresses = getAddresses(hre.network.name);
   await hre.run("verify:verify", {
-    address: "0x8bb175D22cD1B7A86f9D2480fD6B8B7e96fc1B4A",
+    address: (await hre.ethers.getContract("FeeManager")).address,
     constructorArguments: [
       vaultAddress,
       addresses.USDC,

--- a/scripts/verify/verifyPosition.ts
+++ b/scripts/verify/verifyPosition.ts
@@ -3,10 +3,6 @@ import hre from "hardhat";
 async function main() {
   await hre.run("verify:verify", {
     address: (await hre.ethers.getContract("Position")).address,
-    // other args
-    // libraries: {
-    //   Position: (await hre.ethers.getContract("Pool")).address,
-    // },
   });
 }
 

--- a/scripts/verify/verifyVaultV2.ts
+++ b/scripts/verify/verifyVaultV2.ts
@@ -5,7 +5,7 @@ async function main() {
   const addresses: Addresses = getAddresses(hre.network.name);
 
   await hre.run("verify:verify", {
-    address: "0x4d1D8B56EBeD04BC71203D47aED0122DD26FC642",
+    address: (await hre.ethers.getContract("ArrakisV2")).address,
     constructorArguments: [addresses.UniswapV3Factory],
     // other args
     libraries: {

--- a/scripts/verify/verifyVaultV2Helper.ts
+++ b/scripts/verify/verifyVaultV2Helper.ts
@@ -7,7 +7,6 @@ async function main() {
   await hre.run("verify:verify", {
     address: (await hre.ethers.getContract("ArrakisV2Helper")).address,
     constructorArguments: [addresses.UniswapV3Factory],
-    // other args
     libraries: {
       Underlying: (await hre.ethers.getContract("Underlying")).address,
     },

--- a/scripts/verify/verifyVaultV2Resolver.ts
+++ b/scripts/verify/verifyVaultV2Resolver.ts
@@ -7,7 +7,6 @@ async function main() {
   await hre.run("verify:verify", {
     address: (await hre.ethers.getContract("ArrakisV2Resolver")).address,
     constructorArguments: [addresses.UniswapV3Factory],
-    // other args
     libraries: {
       Position: (await hre.ethers.getContract("Position")).address,
       Underlying: (await hre.ethers.getContract("Underlying")).address,

--- a/test/integration_tests/ArrakisV2.test.ts
+++ b/test/integration_tests/ArrakisV2.test.ts
@@ -229,10 +229,13 @@ describe("Arrakis V2 integration test!!!", async function () {
       user
     )) as ArrakisV2;
 
+    const chaosTokenFactory = await ethers.getContractFactory("MockERC20");
+    const chaosToken = await chaosTokenFactory.deploy();
     const feeManagerFactory = await ethers.getContractFactory("FeeManager");
     feeManager = (await feeManagerFactory.deploy(
       vaultV2.address,
       addresses.USDC,
+      chaosToken.address,
       addresses.SwapRouter02,
       3000
     )) as IFeeManager;

--- a/test/integration_tests/Rounding.test.ts
+++ b/test/integration_tests/Rounding.test.ts
@@ -205,10 +205,13 @@ describe("Rounding integration test", async function () {
       user
     )) as ArrakisV2;
 
+    const chaosTokenFactory = await ethers.getContractFactory("MockERC20");
+    const chaosToken = await chaosTokenFactory.deploy();
     const feeManagerFactory = await ethers.getContractFactory("FeeManager");
     const feeManager = await feeManagerFactory.deploy(
       vaultV2.address,
       addresses.USDC,
+      chaosToken.address,
       addresses.SwapRouter02,
       3000
     );

--- a/test/unit_tests/ArrakisV2.test.ts
+++ b/test/unit_tests/ArrakisV2.test.ts
@@ -35,10 +35,13 @@ describe("ArrakisV2 functions unit test", function () {
 
     arrakisV2 = await ethers.getContract("ArrakisV2", arrakisTreasury);
 
+    const chaosTokenFactory = await ethers.getContractFactory("MockERC20");
+    const chaosToken = await chaosTokenFactory.deploy();
     const feeManagerFactory = await ethers.getContractFactory("FeeManager");
     const feeManager = await feeManagerFactory.deploy(
       arrakisV2.address,
       addresses.USDC,
+      chaosToken.address,
       addresses.SwapRouter02,
       3000
     );

--- a/test/unit_tests/ArrakisV2Helper.test.ts
+++ b/test/unit_tests/ArrakisV2Helper.test.ts
@@ -133,10 +133,14 @@ describe("ArrakisV2Helper functions unit test", function () {
         user
       )) as ArrakisV2;
 
+      const chaosTokenFactory = await ethers.getContractFactory("MockERC20");
+      const chaosToken = await chaosTokenFactory.deploy();
+
       const feeManagerFactory = await ethers.getContractFactory("FeeManager");
       const feeManager = await feeManagerFactory.deploy(
         arrakisV2.address,
         addresses.USDC,
+        chaosToken.address,
         addresses.SwapRouter02,
         3000
       );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a `chaos` token to enhance fee management and reward claiming.
	- Added functionality for owners to withdraw `chaos` tokens and set conversion rates.
	- New event logging for rewards claimed and rewards converted to USDC, improving transparency for users.

- **Bug Fixes**
	- Enhanced validation for constructor parameters in the `FeeManager` to prevent invalid addresses.

- **Tests**
	- Expanded testing coverage for the `FeeManager` and `ArrakisV2` contracts, including scenarios for minting, burning, and fee distribution, as well as edge cases related to rate settings and withdrawals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->